### PR TITLE
runtime issue fix

### DIFF
--- a/0_session-install-dependencies/start_application.py
+++ b/0_session-install-dependencies/start_application.py
@@ -27,7 +27,12 @@ client = cmlapi.default_client(
 )
 available_runtimes = client.list_runtimes(
     search_filter=json.dumps(
-        {"kernel": "Python 3.11", "edition": "Nvidia GPU", "editor": "PBJ Workbench"}
+        {
+            "kernel": "Python 3.11",
+            "edition": "Nvidia GPU",
+            "editor": "PBJ Workbench",
+            "image_identifier": "ml-runtime-pbj-workbench-python3.11-cuda",
+        }
     )
 )
 print(available_runtimes)


### PR DESCRIPTION
The AMP uses list_runtimes to get the list of runtime in the workspace with the given search filer.
The search filter implementation is doing a like query in DB, and so all the runtimes that have kernel, editor and edition as the given search filter are returned.
If the user has a custom runtime with the same kernel, editor and edition that will be returned and will be used which is not what we want.
We want the ml runtime for pbj workbench for python 3.11.
So as a fix, I added the image_identifier to the search filter.
